### PR TITLE
Fix proxy_pass URL in Nginx configuration

### DIFF
--- a/grifballwebapp.client/default.conf
+++ b/grifballwebapp.client/default.conf
@@ -72,7 +72,7 @@ server {
 
   #https://learn.microsoft.com/en-us/aspnet/core/signalr/scale?view=aspnetcore-8.0#linux-with-nginx
   location /hub/ {
-	  proxy_pass http://grifballwebapp.server:5295/;
+	  proxy_pass http://grifballwebapp-server:5295/;
 
     # Configuration for WebSockets
     proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Update to grifballwebapp-server for server name. Required for kubernetes which does not support . in name